### PR TITLE
Added scope to JWT

### DIFF
--- a/oauth2_provider_jwt/authentication.py
+++ b/oauth2_provider_jwt/authentication.py
@@ -13,11 +13,11 @@ from .utils import decode_jwt
 
 class JwtToken(dict):
     """
-    Mimics the structure of AbstractAccessToken so you can use standard Django Oauth Toolkit
-    permissions like `TokenHasScope`.
+    Mimics the structure of `AbstractAccessToken` so you can use standard
+    Django Oauth Toolkit permissions like `TokenHasScope`.
     """
     def __init__(self, payload):
-        super().__init__(**payload)
+        super(JwtToken, self).__init__(**payload)
 
     def __getattr__(self, item):
         return self[item]

--- a/oauth2_provider_jwt/views.py
+++ b/oauth2_provider_jwt/views.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class TokenView(views.TokenView):
-    def _get_access_token_jwt(self, request, expires_in, content):
+    def _get_access_token_jwt(self, request, content):
         extra_data = {}
         issuer = settings.JWT_ISSUER
         payload_enricher = getattr(settings, 'JWT_PAYLOAD_ENRICHER', None)
@@ -25,7 +25,7 @@ class TokenView(views.TokenView):
 
         if request.POST.get('username'):
             extra_data['username'] = request.POST.get('username')
-        payload = generate_payload(issuer, expires_in, **extra_data)
+        payload = generate_payload(issuer, content['expires_in'], **extra_data)
         token = encode_jwt(payload)
         return token
 
@@ -48,7 +48,7 @@ class TokenView(views.TokenView):
                     'Missing JWT configuration, skipping token build')
             else:
                 content['access_token_jwt'] = self._get_access_token_jwt(
-                    request, content['expires_in'], content)
+                    request, content)
                 try:
                     content = bytes(json.dumps(content), 'utf-8')
                 except TypeError:

--- a/oauth2_provider_jwt/views.py
+++ b/oauth2_provider_jwt/views.py
@@ -12,13 +12,17 @@ logger = logging.getLogger(__name__)
 
 
 class TokenView(views.TokenView):
-    def _get_access_token_jwt(self, request, expires_in):
+    def _get_access_token_jwt(self, request, expires_in, content):
         extra_data = {}
         issuer = settings.JWT_ISSUER
         payload_enricher = getattr(settings, 'JWT_PAYLOAD_ENRICHER', None)
         if payload_enricher:
             fn = import_string(payload_enricher)
             extra_data = fn(request)
+
+        if 'scope' in content:
+            extra_data['scope'] = content['scope']
+
         if request.POST.get('username'):
             extra_data['username'] = request.POST.get('username')
         payload = generate_payload(issuer, expires_in, **extra_data)
@@ -44,7 +48,7 @@ class TokenView(views.TokenView):
                     'Missing JWT configuration, skipping token build')
             else:
                 content['access_token_jwt'] = self._get_access_token_jwt(
-                    request, content['expires_in'])
+                    request, content['expires_in'], content)
                 try:
                     content = bytes(json.dumps(content), 'utf-8')
                 except TypeError:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -98,3 +98,35 @@ class JWTAuthenticationTests(TestCase):
                 HTTP_AUTHORIZATION='JWT {}'.format(jwt_value),
                 content_type='application/json')
             self.assertEqual(response.status_code, 403)
+
+    def test_post_valid_jwt_with_auth_and_scope_not_valid(self):
+        now = datetime.utcnow()
+        payload = {
+            'iss': 'issuer',
+            'exp': now + timedelta(seconds=100),
+            'iat': now,
+            'username': 'temporary',
+            'scope': 'read',  # Incorrect scope
+        }
+        jwt_value = utils.encode_jwt(payload)
+        response = self.client.post(
+            '/jwt_auth_scope/', {'example': 'example'},
+            HTTP_AUTHORIZATION='JWT {}'.format(jwt_value),
+            content_type='application/json')
+        self.assertEqual(response.status_code, 403)
+
+    def test_post_valid_jwt_with_auth_and_scope_is_valid(self):
+        now = datetime.utcnow()
+        payload = {
+            'iss': 'issuer',
+            'exp': now + timedelta(seconds=100),
+            'iat': now,
+            'username': 'temporary',
+            'scope': 'write',  # Correct scope
+        }
+        jwt_value = utils.encode_jwt(payload)
+        response = self.client.post(
+            '/jwt_auth_scope/', {'example': 'example'},
+            HTTP_AUTHORIZATION='JWT {}'.format(jwt_value),
+            content_type='application/json')
+        self.assertEqual(response.status_code, 200)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -5,6 +5,7 @@ from django.contrib import admin
 from django.http import HttpResponse
 from rest_framework import permissions
 from rest_framework.views import APIView
+from oauth2_provider.contrib.rest_framework import TokenHasScope
 
 admin.autodiscover()
 
@@ -31,11 +32,24 @@ class MockForAuthView(APIView):
         return HttpResponse(response)
 
 
+class MockForAuthScopeView(APIView):
+    permission_classes = (TokenHasScope,)
+    required_scopes = ['write']
+
+    def get(self, _request):
+        return HttpResponse('mockforauthscopeview-get')
+
+    def post(self, request):
+        response = json.dumps({"username": request.user.username})
+        return HttpResponse(response)
+
+
 urlpatterns = [
     url(r"^o/", include("oauth2_provider_jwt.urls",
                         namespace="oauth2_provider_jwt")),
     url(r'^jwt/$', MockView.as_view()),
     url(r'^jwt_auth/$', MockForAuthView.as_view()),
+    url(r'^jwt_auth_scope/$', MockForAuthScopeView.as_view()),
 ]
 
 


### PR DESCRIPTION
Hi there,

Great library - thanks for the effort!

This is just a small patch which made my life easier trying to integrate JWT with OAuth scopes.

Getting the scope into the JWT is extremely useful for handling permissions later.

In particular, it means that you can use the `TokenHasScope` permission from DOT.