### PR TITLE
update dependencies and drop py2.7 and django1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,11 @@ docker-compose run dot_jwt
 ```
 
 ----------
-To run the tests only for Python 2.7:
+To run the tests only for Python 3.6:
 
 ```shell script
-docker-compose run dot_jwt_27
+docker-compose run dot_jwt_36
 ```
 
-There are tests configured for all currently supported Python-Versions ( and sadly 2.7).
-Just exchange the suffix of the docker-compose service tag with zour major-minor combination.
+There are tests configured for all currently supported Python-Versions.
+Just exchange the suffix of the docker-compose service tag with your major-minor combination.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     entrypoint:
       - /home/python/.local/bin/tox
       - -e
-      - py38-django111,py38-django22,py38-django30,flake8
+      - py38-django22,py38-django30,flake8
 
   dot_jwt_37:
     build:
@@ -29,7 +29,7 @@ services:
     entrypoint:
       - /home/python/.local/bin/tox
       - -e
-      - py37-django111,py37-django22,py37-django30,flake8
+      - py37-django22,py37-django30,flake8
 
   dot_jwt_36:
     build:
@@ -44,19 +44,4 @@ services:
     entrypoint:
       - /home/python/.local/bin/tox
       - -e
-      - py36-django111,py36-django22,py36-django30,flake8
-
-  dot_jwt_27:
-    build:
-      context: .
-      args:
-        - PY_VERSION=2.7
-      dockerfile: Dockerfile.dev
-    container_name: dot_jwt_27
-    image: dot_jwt_27
-    volumes:
-      - .:/home/python/code
-    entrypoint:
-     - /home/python/.local/bin/tox
-     - -e
-     - py27-django111,py27-django22,flake8
+      - py36-django22,py36-django30,flake8

--- a/oauth2_provider_jwt/authentication.py
+++ b/oauth2_provider_jwt/authentication.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.auth import get_user_model
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 import jwt
 from rest_framework import exceptions
 from rest_framework.authentication import (
@@ -127,7 +127,7 @@ class JWTAuthentication(BaseAuthentication):
                 return request.COOKIES.get(settings.JWT_AUTH_COOKIE)
             return None
 
-        if smart_text(auth[0]) != auth_header_prefix:
+        if smart_str(auth[0]) != auth_header_prefix:
             return None
 
         if len(auth) == 1:

--- a/oauth2_provider_jwt/views.py
+++ b/oauth2_provider_jwt/views.py
@@ -2,11 +2,7 @@ import ast
 import json
 import logging
 
-try:
-    from urllib.parse import urlencode, urlparse, parse_qs
-except ImportError:
-    from urllib import urlencode # noqa
-    from urlparse import urlparse, parse_qs
+from urllib.parse import urlencode, urlparse, parse_qs  # noqa
 
 from django.conf import settings
 from django.utils.module_loading import import_string

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-cryptography==2.7
-PyJWT>=1.6.4,<1.7
+cryptography~=2.8
+PyJWT~=1.7.1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'oauth2_provider_jwt',
     ],
     name='django-oauth-toolkit-jwt',
-    version='0.6.0',
+    version='0.7.0',
     url='https://github.com/Humanitec/django-oauth-toolkit-jwt.git',
     description='Extension that adds JWT support.',
     provides=['oauth2_provider_jwt', ],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,7 @@
 import base64
 from datetime import datetime, timedelta
 import json
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 from unittest import TestCase as PythonTestCase
 
 from django.core.exceptions import ImproperlyConfigured

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,15 +3,8 @@ import datetime
 import json
 import re
 
-try:
-    from urllib.parse import urlencode, urlparse, parse_qs
-except ImportError:
-    from urllib import urlencode # noqa
-    from urlparse import urlparse, parse_qs
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from urllib.parse import urlencode, urlparse, parse_qs  # noqa
+from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -122,8 +115,9 @@ class PasswordTokenViewTest(TestCase):
         self.assertEqual(content["scope"], "read write")
         self.assertEqual(content["expires_in"],
                          oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS)
-        self.assertDictContainsSubset({'scope': 'read write'},
-                                      self.decode_jwt(jwt_token))
+        self.assertTrue('scope' in self.decode_jwt(jwt_token))
+        self.assertEqual(self.decode_jwt(jwt_token).get('scope'),
+                         'read write')
 
     def test_get_token_authorization_code(self):
         """
@@ -282,8 +276,9 @@ class PasswordTokenViewTest(TestCase):
             **auth_headers)
         content = json.loads(response.content.decode("utf-8"))
         access_token_jwt = content["access_token_jwt"]
-        self.assertDictContainsSubset({'sub': 'unique-user'},
-                                      self.decode_jwt(access_token_jwt))
+        self.assertTrue('sub' in self.decode_jwt(access_token_jwt))
+        self.assertEqual(self.decode_jwt(access_token_jwt).get('sub'),
+                         'unique-user')
 
     def test_get_custom_scope_in_jwt(self):
         token_request_data = {
@@ -300,8 +295,9 @@ class PasswordTokenViewTest(TestCase):
             **auth_headers)
         content = json.loads(response.content.decode("utf-8"))
         access_token_jwt = content["access_token_jwt"]
-        self.assertDictContainsSubset({'scope': 'read'},
-                                      self.decode_jwt(access_token_jwt))
+        self.assertTrue('scope' in self.decode_jwt(access_token_jwt))
+        self.assertEqual(self.decode_jwt(access_token_jwt).get('scope'),
+                         'read')
 
     def test_refresh_token(self):
         access_token = AccessToken.objects.create(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38}-django{111, 22, 30},py27-django{111, 22},flake8
+envlist = {py36,py37,py38}-django{22, 30},flake8
 
 [pytest]
 django_find_project = false
@@ -11,29 +11,11 @@ setenv =
 	PYTHONPATH = {toxinidir}
 deps =
 	-r{toxinidir}/requirements.txt
-	django111: Django<1.12
-	django111: django-oauth-toolkit>=1.1.2,<1.2
 	django22: Django<3
 	django30: Django>=3,<3.1
-	!django111: django-oauth-toolkit>=1.1.2,<=1.2
-	djangorestframework>=3.7
-	pyjwt>=1.6.4,<1.7
-	pytest
-	pytest-django
-
-[testenv:py27-django{111,22}]
-commands = pytest {posargs}
-setenv =
-	DJANGO_SETTINGS_MODULE = tests.settings
-	PYTHONPATH = {toxinidir}
-deps =
-	-r{toxinidir}/requirements.txt
-	django111: Django<1.12
-	django22: Django<3
-	pyjwt>=1.6.4
-	mock
-	djangorestframework>=3.7,<3.10
-	django-oauth-toolkit>=1.1.2,<=1.12
+	django-oauth-toolkit~=1.3
+	djangorestframework~=3.11
+	pyjwt~=1.7.1
 	pytest
 	pytest-django
 


### PR DESCRIPTION
This removes Python 2.7 and Django 1.11 support completely as they are no longer maintained.
So the last version that supports them is [v0.6.0](https://github.com/Humanitec/django-oauth-toolkit-jwt/releases/tag/v0.6.0).
Also third-party dependencies are updated.

Fixes #25 