### PR TITLE
Remove cryptography requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-cryptography~=2.8
 PyJWT~=1.7.1


### PR DESCRIPTION
- django-oauth-toolkit-jwt does not directly rely on the cryptography
  library so it is not needed. Pinning the old version has the potential
  to create dependency issues.