### PR TITLE
Replace deprecated django.conf.urls.url with django.urls.re_path

### DIFF
--- a/oauth2_provider_jwt/urls.py
+++ b/oauth2_provider_jwt/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 from oauth2_provider import views
 
 from .views import TokenView, JWTAuthorizationView
@@ -6,10 +6,10 @@ from .views import TokenView, JWTAuthorizationView
 app_name = "oauth2_provider_jwt"
 
 urlpatterns = [
-    url(r"^authorize/$", JWTAuthorizationView.as_view(), name="authorize"),
-    url(r"^token/$", TokenView.as_view(), name="token"),
-    url(r"^revoke_token/$", views.RevokeTokenView.as_view(),
-        name="revoke-token"),
-    url(r"^introspect/$", views.IntrospectTokenView.as_view(),
-        name="introspect"),
+    re_path(r"^authorize/$", JWTAuthorizationView.as_view(), name="authorize"),
+    re_path(r"^token/$", TokenView.as_view(), name="token"),
+    re_path(r"^revoke_token/$", views.RevokeTokenView.as_view(),
+            name="revoke-token"),
+    re_path(r"^introspect/$", views.IntrospectTokenView.as_view(),
+            name="introspect"),
 ]


### PR DESCRIPTION
Adresses the following warning:
`RemovedInDjango40Warning: django.conf.urls.url() is deprecated in favor of django.urls.re_path().`